### PR TITLE
chore(CI): Disable release dryrun mode

### DIFF
--- a/packages/module/release.config.js
+++ b/packages/module/release.config.js
@@ -9,6 +9,5 @@ module.exports = {
     '@semantic-release/github',
     '@semantic-release/npm'
   ],
-  tagFormat: 'prerelease-v${version}',
-  dryRun: true
+  tagFormat: 'prerelease-v${version}'
 };


### PR DESCRIPTION
Closes patternfly/patternfly-extension-issues#40

Convenience link to last release dryrun: https://github.com/patternfly/react-virtualized-extension/actions/runs/4472834661/jobs/7859545126