### PR TITLE
feat(VirtualSelectList): add virtualized list for Select/Menu dropdowns

### DIFF
--- a/packages/module/patternfly-docs/content/examples/VirtualSelectList.md
+++ b/packages/module/patternfly-docs/content/examples/VirtualSelectList.md
@@ -1,0 +1,40 @@
+---
+id: Virtual select list
+section: extensions
+source: react
+sourceLink: https://github.com/patternfly/react-virtualized-extension
+propComponents: ['VirtualSelectList']
+---
+
+Note: React Virtualized Extension lives in its own package at [`@patternfly/react-virtualized-extension`](https://www.npmjs.com/package/@patternfly/react-virtualized-extension)!
+
+import { VirtualSelectList } from '@patternfly/react-virtualized-extension';
+import { Select, SelectOption, MenuToggle, TextInputGroup, TextInputGroupMain, TextInputGroupUtilities, Button, Badge } from '@patternfly/react-core';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import { useState, useMemo, useRef } from 'react';
+
+## About
+
+VirtualSelectList is a virtualized replacement for PatternFly's SelectList component. It renders only the visible items in a scrollable dropdown, enabling Select menus with thousands of options without DOM performance degradation.
+
+Use VirtualSelectList as a drop-in replacement for `<SelectList>` inside a composable `<Select>`. The `itemRenderer` callback receives positioning styles that must be applied to each rendered `<SelectOption>`.
+
+## Examples
+
+### Basic
+
+```js file="./VirtualSelectListBasic.tsx"
+
+```
+
+### Typeahead with filtering
+
+```js file="./VirtualSelectListTypeahead.tsx"
+
+```
+
+### Multi-select
+
+```js file="./VirtualSelectListMulti.tsx"
+
+```

--- a/packages/module/patternfly-docs/content/examples/VirtualSelectListBasic.tsx
+++ b/packages/module/patternfly-docs/content/examples/VirtualSelectListBasic.tsx
@@ -1,0 +1,52 @@
+import { useState, FunctionComponent } from 'react';
+import { Select, SelectOption, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+import { VirtualSelectList } from '@patternfly/react-virtualized-extension';
+
+export const VirtualSelectListBasicExample: FunctionComponent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<string>();
+
+  const items: string[] = [];
+  for (let i = 0; i < 10000; i++) {
+    items.push(`Option ${i}`);
+  }
+
+  const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
+    setSelected(value as string);
+    setIsOpen(false);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen((prev) => !prev)}
+      isExpanded={isOpen}
+      style={{ width: '200px' } as React.CSSProperties}
+    >
+      {selected || 'Select an option'}
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      isOpen={isOpen}
+      selected={selected}
+      onSelect={onSelect}
+      onOpenChange={setIsOpen}
+      toggle={toggle}
+      isScrollable
+    >
+      <VirtualSelectList
+        rowCount={items.length}
+        rowHeight={36}
+        maxHeight={300}
+        aria-label="Basic virtualized select"
+        rowRenderer={({ index, style, key }) => (
+          <SelectOption key={key} style={style} value={items[index]} isSelected={selected === items[index]}>
+            {items[index]}
+          </SelectOption>
+        )}
+      />
+    </Select>
+  );
+};

--- a/packages/module/patternfly-docs/content/examples/VirtualSelectListMulti.tsx
+++ b/packages/module/patternfly-docs/content/examples/VirtualSelectListMulti.tsx
@@ -1,0 +1,76 @@
+import { useState, FunctionComponent } from 'react';
+import {
+  Select,
+  SelectOption,
+  MenuToggle,
+  MenuToggleElement,
+  Badge
+} from '@patternfly/react-core';
+import { VirtualSelectList } from '@patternfly/react-virtualized-extension';
+
+export const VirtualSelectListMultiExample: FunctionComponent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedItems, setSelectedItems] = useState<string[]>([]);
+
+  const items: string[] = [];
+  for (let i = 0; i < 1000; i++) {
+    items.push(`Option ${i}`);
+  }
+
+  const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
+    const val = value as string;
+    setSelectedItems((prev) =>
+      prev.includes(val) ? prev.filter((item) => item !== val) : [...prev, val]
+    );
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen((prev) => !prev)}
+      isExpanded={isOpen}
+      style={{ width: '300px' } as React.CSSProperties}
+    >
+      {selectedItems.length > 0 ? (
+        <>
+          {selectedItems.length} selected
+          <Badge isRead className="pf-v6-u-ml-sm">
+            {selectedItems.length}
+          </Badge>
+        </>
+      ) : (
+        'Select options'
+      )}
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      isOpen={isOpen}
+      selected={selectedItems}
+      onSelect={onSelect}
+      onOpenChange={setIsOpen}
+      toggle={toggle}
+      isScrollable
+    >
+      <VirtualSelectList
+        rowCount={items.length}
+        rowHeight={36}
+        maxHeight={300}
+        isAriaMultiselectable
+        aria-label="Multi-select virtualized list"
+        rowRenderer={({ index, style, key }) => (
+          <SelectOption
+            key={key}
+            style={style}
+            value={items[index]}
+            hasCheckbox
+            isSelected={selectedItems.includes(items[index])}
+          >
+            {items[index]}
+          </SelectOption>
+        )}
+      />
+    </Select>
+  );
+};

--- a/packages/module/patternfly-docs/content/examples/VirtualSelectListTypeahead.tsx
+++ b/packages/module/patternfly-docs/content/examples/VirtualSelectListTypeahead.tsx
@@ -1,0 +1,114 @@
+import { useState, useMemo, useRef, FunctionComponent } from 'react';
+import {
+  Select,
+  SelectOption,
+  MenuToggle,
+  MenuToggleElement,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  Button
+} from '@patternfly/react-core';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import { VirtualSelectList, VirtualSelectListRef } from '@patternfly/react-virtualized-extension';
+
+const allItems: string[] = [];
+for (let i = 0; i < 10000; i++) {
+  allItems.push(`Option ${i}`);
+}
+
+export const VirtualSelectListTypeaheadExample: FunctionComponent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<string>();
+  const [filterValue, setFilterValue] = useState('');
+  const listRef = useRef<VirtualSelectListRef>(null);
+
+  const filteredItems = useMemo(
+    () =>
+      filterValue
+        ? allItems.filter((item) => item.toLowerCase().includes(filterValue.toLowerCase()))
+        : allItems,
+    [filterValue]
+  );
+
+  const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
+    setSelected(value as string);
+    setFilterValue('');
+    setIsOpen(false);
+  };
+
+  const onInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+    setFilterValue(value);
+    if (!isOpen) {
+      setIsOpen(true);
+    }
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      variant="typeahead"
+      onClick={() => setIsOpen((prev) => !prev)}
+      isExpanded={isOpen}
+      isFullWidth
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={filterValue || selected || ''}
+          onClick={() => setIsOpen(true)}
+          onChange={onInputChange}
+          autoComplete="off"
+          placeholder="Search from 10,000 options..."
+        />
+        {(filterValue || selected) && (
+          <TextInputGroupUtilities>
+            <Button
+              variant="plain"
+              onClick={() => {
+                setSelected(undefined);
+                setFilterValue('');
+              }}
+              aria-label="Clear input"
+            >
+              <TimesIcon />
+            </Button>
+          </TextInputGroupUtilities>
+        )}
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      isOpen={isOpen}
+      selected={selected}
+      onSelect={onSelect}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) {
+          setFilterValue('');
+        }
+      }}
+      toggle={toggle}
+      isScrollable
+    >
+      <VirtualSelectList
+        ref={listRef}
+        rowCount={filteredItems.length}
+        rowHeight={36}
+        maxHeight={300}
+        aria-label="Typeahead virtualized select"
+        noRowsRenderer={() => (
+          <li className="pf-v6-c-menu__list-item pf-m-disabled" role="option" aria-disabled="true">
+            No results found for &quot;{filterValue}&quot;
+          </li>
+        )}
+        rowRenderer={({ index, style, key }) => (
+          <SelectOption key={key} style={style} value={filteredItems[index]} isSelected={selected === filteredItems[index]}>
+            {filteredItems[index]}
+          </SelectOption>
+        )}
+      />
+    </Select>
+  );
+};

--- a/packages/module/src/components/Virtualized/VirtualGrid.ts
+++ b/packages/module/src/components/Virtualized/VirtualGrid.ts
@@ -239,6 +239,11 @@ export interface VirtualGridProps {
 
   /** Inner Scroll Container element to render */
   innerScrollContainerComponent?: string | ComponentType<any>;
+
+  /** Optional custom CSS class name for the inner scroll container.
+   *  Defaults to 'pf-v6-c-table__tbody' for backward compatibility with table-based usage.
+   */
+  innerScrollContainerClassName?: string;
 }
 
 interface InstanceProps {
@@ -920,7 +925,8 @@ export class VirtualGrid extends Component<VirtualGridProps, VirtualGridState> {
       tabIndex,
       width,
       scrollContainerComponent,
-      innerScrollContainerComponent
+      innerScrollContainerComponent,
+      innerScrollContainerClassName
     } = this.props;
     const { instanceProps, needToResetStyleCache } = this.state;
 
@@ -1008,7 +1014,7 @@ export class VirtualGrid extends Component<VirtualGridProps, VirtualGridState> {
     let innerScrollContainer = null;
     if (childrenToDisplay.length > 0) {
       const innerScrollContainerProps = {
-        className: 'ReactVirtualized__VirtualGrid__innerScrollContainer pf-v6-c-table__tbody',
+        className: css('ReactVirtualized__VirtualGrid__innerScrollContainer', innerScrollContainerClassName ?? 'pf-v6-c-table__tbody'),
         key: 'ReactVirtualized__VirtualGrid__innerScrollContainer',
         role: containerRole,
         style: {

--- a/packages/module/src/components/Virtualized/VirtualSelectList.test.tsx
+++ b/packages/module/src/components/Virtualized/VirtualSelectList.test.tsx
@@ -1,0 +1,321 @@
+import { render, fireEvent } from '@testing-library/react';
+import { VirtualSelectList } from './VirtualSelectList';
+
+const defaultRowRenderer = ({ index, style, key }: { index: number; style: React.CSSProperties; key: string }) => (
+  <li key={key} style={style} role="option" aria-selected={false}>
+    Option {index}
+  </li>
+);
+
+describe('VirtualSelectList', () => {
+  test('renders with correct ARIA attributes', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={10}
+          rowHeight={36}
+          rowRenderer={defaultRowRenderer}
+          aria-label="Test select list"
+        />
+      </div>
+    );
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).toBeTruthy();
+    expect(listbox?.getAttribute('aria-label')).toBe('Test select list');
+  });
+
+  test('does not render aria-readonly on the listbox', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={10}
+          rowHeight={36}
+          rowRenderer={defaultRowRenderer}
+        />
+      </div>
+    );
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.hasAttribute('aria-readonly')).toBe(false);
+  });
+
+  test('does not render role=rowgroup on the inner container', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={10}
+          rowHeight={36}
+          rowRenderer={defaultRowRenderer}
+        />
+      </div>
+    );
+
+    expect(container.querySelector('[role="rowgroup"]')).toBeNull();
+  });
+
+  test('renders aria-multiselectable when isAriaMultiselectable is true', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={10}
+          rowHeight={36}
+          rowRenderer={defaultRowRenderer}
+          isAriaMultiselectable
+        />
+      </div>
+    );
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.getAttribute('aria-multiselectable')).toBe('true');
+  });
+
+  test('does not render aria-multiselectable when isAriaMultiselectable is false', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={10}
+          rowHeight={36}
+          rowRenderer={defaultRowRenderer}
+          isAriaMultiselectable={false}
+        />
+      </div>
+    );
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.hasAttribute('aria-multiselectable')).toBe(false);
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={10}
+          rowHeight={36}
+          rowRenderer={defaultRowRenderer}
+          className="custom-class"
+        />
+      </div>
+    );
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.className).toContain('custom-class');
+  });
+
+  test('renders only visible rows, not all rows', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={1000}
+          rowHeight={36}
+          maxHeight={200}
+          rowRenderer={defaultRowRenderer}
+          overscanRowCount={2}
+        />
+      </div>
+    );
+
+    const items = container.querySelectorAll('[role="option"]');
+    expect(items.length).toBeLessThan(1000);
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  test('renders empty state when rowCount is 0', () => {
+    const { getByText } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={0}
+          rowHeight={36}
+          rowRenderer={defaultRowRenderer}
+          noRowsRenderer={() => <li>No items found</li>}
+        />
+      </div>
+    );
+
+    expect(getByText('No items found')).toBeTruthy();
+  });
+
+  test('calls onRowsRendered when rows are rendered', () => {
+    const onRowsRendered = jest.fn();
+
+    render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={100}
+          rowHeight={36}
+          maxHeight={200}
+          rowRenderer={defaultRowRenderer}
+          onRowsRendered={onRowsRendered}
+        />
+      </div>
+    );
+
+    expect(onRowsRendered).toHaveBeenCalled();
+    const args = onRowsRendered.mock.calls[0][0];
+    expect(args).toHaveProperty('startIndex');
+    expect(args).toHaveProperty('stopIndex');
+    expect(args).toHaveProperty('overscanStartIndex');
+    expect(args).toHaveProperty('overscanStopIndex');
+  });
+
+  test('attaches data-row-index to rendered rows', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={10}
+          rowHeight={36}
+          rowRenderer={defaultRowRenderer}
+        />
+      </div>
+    );
+
+    const items = container.querySelectorAll('[data-row-index]');
+    expect(items.length).toBeGreaterThan(0);
+    expect(items[0].getAttribute('data-row-index')).toBe('0');
+  });
+
+  test('has pf-v6-c-menu__list class on the listbox', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={5}
+          rowHeight={36}
+          rowRenderer={defaultRowRenderer}
+        />
+      </div>
+    );
+
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.className).toContain('pf-v6-c-menu__list');
+  });
+
+  describe('keyboard navigation', () => {
+    const renderWithButtons = (rowCount = 10) => {
+      const result = render(
+        <div style={{ width: 300, height: 300 }}>
+          <VirtualSelectList
+            rowCount={rowCount}
+            rowHeight={36}
+            rowRenderer={({ index, style, key }) => (
+              <li key={key} style={style} role="option" aria-selected={false}>
+                <button>Option {index}</button>
+              </li>
+            )}
+          />
+        </div>
+      );
+      const listbox = result.container.querySelector('[role="listbox"]')!;
+      return { ...result, listbox };
+    };
+
+    test('ArrowDown advances focused index', () => {
+      const { listbox, container } = renderWithButtons();
+
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+
+      const focused = container.querySelector('[data-row-index="0"] button');
+      expect(focused).toBeTruthy();
+      expect(document.activeElement === focused || container.querySelectorAll('[data-row-index]').length > 0).toBe(true);
+
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      const items = container.querySelectorAll('[data-row-index]');
+      expect(items.length).toBeGreaterThan(1);
+    });
+
+    test('ArrowUp moves focus backward', () => {
+      const { listbox, container } = renderWithButtons();
+
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+
+      const items = container.querySelectorAll('[data-row-index]');
+      expect(items.length).toBeGreaterThan(0);
+    });
+
+    test('Home moves focus to the first row', () => {
+      const { listbox, container } = renderWithButtons();
+
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: 'Home' });
+
+      const firstItem = container.querySelector('[data-row-index="0"]');
+      expect(firstItem).toBeTruthy();
+    });
+
+    test('End moves focus to the last row', () => {
+      const { listbox, container } = renderWithButtons(5);
+
+      fireEvent.keyDown(listbox, { key: 'End' });
+
+      const lastItem = container.querySelector('[data-row-index="4"]');
+      expect(lastItem).toBeTruthy();
+    });
+
+    test('ArrowDown does not go past the last row', () => {
+      const { listbox, container } = renderWithButtons(3);
+
+      fireEvent.keyDown(listbox, { key: 'End' });
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+
+      const items = container.querySelectorAll('[data-row-index]');
+      const lastIndex = Math.max(...Array.from(items).map((el) => parseInt(el.getAttribute('data-row-index')!, 10)));
+      expect(lastIndex).toBe(2);
+    });
+
+    test('ArrowUp does not go before the first row', () => {
+      const { listbox, container } = renderWithButtons();
+
+      fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+
+      const firstItem = container.querySelector('[data-row-index="0"]');
+      expect(firstItem).toBeTruthy();
+    });
+
+    test('keyboard events are ignored when rowCount is 0', () => {
+      const { listbox } = renderWithButtons(0);
+
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+      fireEvent.keyDown(listbox, { key: 'Home' });
+      fireEvent.keyDown(listbox, { key: 'End' });
+    });
+  });
+
+  test('constrains height to maxHeight when rows exceed it', () => {
+    const { container } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={100}
+          rowHeight={36}
+          maxHeight={200}
+          rowRenderer={defaultRowRenderer}
+        />
+      </div>
+    );
+
+    const listbox = container.querySelector('[role="listbox"]');
+    const computedHeight = listbox?.getAttribute('style');
+    expect(computedHeight).toContain('height');
+  });
+
+  test('snapshot', () => {
+    const { asFragment } = render(
+      <div style={{ width: 300, height: 300 }}>
+        <VirtualSelectList
+          rowCount={5}
+          rowHeight={36}
+          maxHeight={300}
+          rowRenderer={defaultRowRenderer}
+          aria-label="Snapshot test"
+        />
+      </div>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/module/src/components/Virtualized/VirtualSelectList.tsx
+++ b/packages/module/src/components/Virtualized/VirtualSelectList.tsx
@@ -1,0 +1,321 @@
+import {
+  cloneElement,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement
+} from 'react';
+
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Menu/menu';
+
+import { VirtualGrid } from './VirtualGrid';
+import accessibilityOverscanIndicesGetter from './accessibilityOverscanIndicesGetter';
+import type { Alignment, CellRendererParams, CellSize, OverscanIndicesGetter, RenderedSection } from './types';
+
+const DEFAULT_ROW_HEIGHT = 36;
+const DEFAULT_MAX_HEIGHT = 300;
+const DEFAULT_OVERSCAN_ROW_COUNT = 5;
+
+export interface VirtualSelectListRowRendererParams {
+  /** Zero-based index of the row */
+  index: number;
+  /** Style object that MUST be applied to the rendered element for correct positioning */
+  style: React.CSSProperties;
+  /** Unique key for the row */
+  key: string;
+  /** Whether the list is currently being scrolled */
+  isScrolling: boolean;
+  /** Whether the row is within the visible viewport (vs. overscan) */
+  isVisible: boolean;
+}
+
+export interface VirtualSelectListProps {
+  /** Total number of rows in the list. */
+  rowCount: number;
+
+  /**
+   * Renderer function for each row. Must return a SelectOption, MenuItem, or compatible element.
+   * The `style` parameter MUST be applied to the rendered element for correct positioning.
+   */
+  rowRenderer: (params: VirtualSelectListRowRendererParams) => ReactElement;
+
+  /**
+   * Height of each row in pixels.
+   * Can be a fixed number or a function that returns the height for a given index.
+   * If a function is provided, memoize it (e.g. with useCallback) to avoid
+   * recalculating total height on every render.
+   * Defaults to 36 (PatternFly's standard menu item height).
+   */
+  rowHeight?: CellSize;
+
+  /**
+   * Maximum height of the scrollable list in pixels.
+   * The list will be shorter if total content height is less than maxHeight.
+   * Defaults to 300.
+   */
+  maxHeight?: number;
+
+  /** Optional CSS class name applied to the list container. */
+  className?: string;
+
+  /** Optional inline style applied to the list container. */
+  style?: React.CSSProperties;
+
+  /**
+   * Indicates to assistive technologies whether more than one row can be selected.
+   * Maps to aria-multiselectable on the list element.
+   */
+  isAriaMultiselectable?: boolean;
+
+  /** Accessible label for the list. */
+  'aria-label'?: string;
+
+  /**
+   * Index to scroll to. When set, the list scrolls to ensure this index is visible.
+   * Use -1 (default) to disable.
+   */
+  scrollToIndex?: number;
+
+  /** Scroll-to alignment behavior. Defaults to 'auto'. */
+  scrollToAlignment?: Alignment;
+
+  /** Number of rows to render above/below the visible area. Defaults to 5. */
+  overscanRowCount?: number;
+
+  /** Custom overscan indices getter for accessibility. */
+  overscanIndicesGetter?: OverscanIndicesGetter;
+
+  /** Callback when the visible range changes. */
+  onRowsRendered?: (params: {
+    overscanStartIndex: number;
+    overscanStopIndex: number;
+    startIndex: number;
+    stopIndex: number;
+  }) => void;
+
+  /** Renderer for empty state when rowCount is 0. */
+  noRowsRenderer?: () => ReactElement;
+}
+
+export interface VirtualSelectListRef {
+  scrollToItem: (index: number) => void;
+}
+
+/**
+ * A virtualized list component designed to replace PatternFly's SelectList
+ * inside a composable Select. Renders only visible items for high performance
+ * with large option counts.
+ */
+export const VirtualSelectList = forwardRef<VirtualSelectListRef, VirtualSelectListProps>(
+  (
+    {
+      rowCount,
+      rowRenderer,
+      rowHeight = DEFAULT_ROW_HEIGHT,
+      maxHeight = DEFAULT_MAX_HEIGHT,
+      className,
+      style: styleProp,
+      isAriaMultiselectable = false,
+      'aria-label': ariaLabel,
+      scrollToIndex: scrollToIndexProp = -1,
+      scrollToAlignment = 'auto',
+      overscanRowCount = DEFAULT_OVERSCAN_ROW_COUNT,
+      overscanIndicesGetter = accessibilityOverscanIndicesGetter,
+      onRowsRendered,
+      noRowsRenderer
+    },
+    ref
+  ) => {
+    const gridRef = useRef<VirtualGrid>(null);
+    const containerRef = useRef<HTMLElement>(null);
+    const [focusedIndex, setFocusedIndex] = useState(-1);
+    const keyDownHandlerRef = useRef<(e: KeyboardEvent<HTMLElement>) => void>(null);
+
+    const scrollToIndex = scrollToIndexProp >= 0 ? scrollToIndexProp : focusedIndex;
+
+    const totalHeight = useMemo(() => {
+      if (typeof rowHeight === 'number') {
+        return rowCount * rowHeight;
+      }
+      let sum = 0;
+      for (let i = 0; i < rowCount; i++) {
+        sum += rowHeight({ index: i });
+      }
+      return sum;
+    }, [rowCount, rowHeight]);
+
+    const height = Math.min(maxHeight, totalHeight) || 1;
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        scrollToItem: (index: number) => {
+          if (gridRef.current) {
+            gridRef.current.scrollToCell({ columnIndex: 0, rowIndex: index });
+          }
+        }
+      }),
+      []
+    );
+
+    useEffect(() => {
+      if (focusedIndex < 0 || !containerRef.current) {
+        return;
+      }
+      const focusableItems = containerRef.current.querySelectorAll<HTMLElement>(
+        'li button:not(:disabled), li input:not(:disabled), li a:not(:disabled)'
+      );
+      for (let i = 0; i < focusableItems.length; i++) {
+        const item = focusableItems[i];
+        const li = item.closest('li');
+        if (li) {
+          const rowIndex = parseInt(li.getAttribute('data-row-index') ?? '', 10);
+          if (rowIndex === focusedIndex) {
+            item.focus();
+            break;
+          }
+        }
+      }
+    }, [focusedIndex]);
+
+    keyDownHandlerRef.current = (e: KeyboardEvent<HTMLElement>) => {
+      if (rowCount === 0) {
+        return;
+      }
+      let nextIndex = focusedIndex;
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          e.stopPropagation();
+          nextIndex = Math.min(focusedIndex + 1, rowCount - 1);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          e.stopPropagation();
+          nextIndex = Math.max(focusedIndex - 1, 0);
+          break;
+        case 'Home':
+          e.preventDefault();
+          e.stopPropagation();
+          nextIndex = 0;
+          break;
+        case 'End':
+          e.preventDefault();
+          e.stopPropagation();
+          nextIndex = rowCount - 1;
+          break;
+        default:
+          return;
+      }
+      setFocusedIndex(nextIndex);
+      if (gridRef.current) {
+        gridRef.current.scrollToCell({ columnIndex: 0, rowIndex: nextIndex });
+      }
+    };
+
+    const stableKeyDownHandler = useCallback((e: KeyboardEvent<HTMLElement>) => {
+      keyDownHandlerRef.current?.(e);
+    }, []);
+
+    const cellRenderer = useCallback(
+      ({ rowIndex, style: cellStyle, isScrolling, isVisible, key }: CellRendererParams) => {
+        const { writable } = Object.getOwnPropertyDescriptor(cellStyle, 'width') || {};
+        if (writable) {
+          cellStyle.width = '100%';
+        }
+        const element = rowRenderer({
+          index: rowIndex,
+          style: cellStyle,
+          isScrolling,
+          isVisible,
+          key
+        });
+        return cloneElement(element, { 'data-row-index': rowIndex });
+      },
+      [rowRenderer]
+    );
+
+    const handleSectionRendered = useCallback(
+      ({ rowOverscanStartIndex, rowOverscanStopIndex, rowStartIndex, rowStopIndex }: RenderedSection) => {
+        onRowsRendered?.({
+          overscanStartIndex: rowOverscanStartIndex,
+          overscanStopIndex: rowOverscanStopIndex,
+          startIndex: rowStartIndex,
+          stopIndex: rowStopIndex
+        });
+      },
+      [onRowsRendered]
+    );
+
+    const setGridRef = useCallback((gridInstance: VirtualGrid) => {
+      (gridRef as React.MutableRefObject<VirtualGrid | null>).current = gridInstance;
+    }, []);
+
+    // Stable scroll container component that doesn't change identity across renders.
+    // Uses refs for values that change (ariaLabel, isAriaMultiselectable, keyDownHandler)
+    // to avoid recreating the component and remounting VirtualGrid.
+    const ariaLabelRef = useRef(ariaLabel);
+    const isAriaMultiselectableRef = useRef(isAriaMultiselectable);
+    ariaLabelRef.current = ariaLabel;
+    isAriaMultiselectableRef.current = isAriaMultiselectable;
+
+    const ScrollContainer = useMemo(
+      () =>
+        forwardRef<HTMLUListElement, React.HTMLAttributes<HTMLUListElement>>((props, scrollRef) => (
+          <ul
+            {...props}
+            ref={(el) => {
+              (containerRef as React.MutableRefObject<HTMLElement | null>).current = el;
+              if (typeof scrollRef === 'function') {
+                scrollRef(el);
+              } else if (scrollRef) {
+                (scrollRef as React.MutableRefObject<HTMLUListElement | null>).current = el;
+              }
+            }}
+            role="listbox"
+            aria-label={ariaLabelRef.current}
+            {...(isAriaMultiselectableRef.current && { 'aria-multiselectable': true })}
+            onKeyDown={stableKeyDownHandler as any}
+          />
+        )),
+      [stableKeyDownHandler]
+    );
+
+    return (
+      <VirtualGrid
+        ref={setGridRef as any}
+        autoContainerWidth
+        cellRenderer={cellRenderer}
+        className={css(styles.menuList, className)}
+        columnCount={1}
+        columnWidth={9999}
+        height={height}
+        width={9999}
+        innerScrollContainerClassName=""
+        innerScrollContainerComponent="div"
+        noContentRenderer={noRowsRenderer}
+        onSectionRendered={handleSectionRendered}
+        overscanIndicesGetter={overscanIndicesGetter}
+        overscanRowCount={overscanRowCount}
+        aria-readonly={null}
+        containerRole="presentation"
+        role={undefined}
+        rowCount={rowCount}
+        rowHeight={rowHeight}
+        scrollContainerComponent={ScrollContainer}
+        scrollToAlignment={scrollToAlignment}
+        scrollToRow={scrollToIndex}
+        style={{ width: '100%', boxSizing: 'content-box', ...styleProp }}
+        tabIndex={0}
+      />
+    );
+  }
+);
+
+VirtualSelectList.displayName = 'VirtualSelectList';

--- a/packages/module/src/components/Virtualized/__snapshots__/VirtualSelectList.test.tsx.snap
+++ b/packages/module/src/components/Virtualized/__snapshots__/VirtualSelectList.test.tsx.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VirtualSelectList snapshot 1`] = `
+<DocumentFragment>
+  <div
+    style="width: 300px; height: 300px;"
+  >
+    <ul
+      aria-label="Snapshot test"
+      class="ReactVirtualized__VirtualGrid pf-v6-c-menu__list"
+      role="listbox"
+      style="box-sizing: content-box; direction: ltr; height: 180px; position: relative; width: 100%; will-change: transform; overflow-x: hidden; overflow-y: hidden;"
+      tabindex="0"
+    >
+      <div
+        class="ReactVirtualized__VirtualGrid__innerScrollContainer"
+        role="presentation"
+        style="width: auto; height: 180px; max-width: 9999px; max-height: 180px; overflow: hidden; position: relative;"
+      >
+        <li
+          aria-selected="false"
+          data-row-index="0"
+          role="option"
+          style="height: 36px; left: 0px; position: absolute; top: 0px; width: 100%;"
+        >
+          Option 0
+        </li>
+        <li
+          aria-selected="false"
+          data-row-index="1"
+          role="option"
+          style="height: 36px; left: 0px; position: absolute; top: 36px; width: 100%;"
+        >
+          Option 1
+        </li>
+        <li
+          aria-selected="false"
+          data-row-index="2"
+          role="option"
+          style="height: 36px; left: 0px; position: absolute; top: 72px; width: 100%;"
+        >
+          Option 2
+        </li>
+        <li
+          aria-selected="false"
+          data-row-index="3"
+          role="option"
+          style="height: 36px; left: 0px; position: absolute; top: 108px; width: 100%;"
+        >
+          Option 3
+        </li>
+        <li
+          aria-selected="false"
+          data-row-index="4"
+          role="option"
+          style="height: 36px; left: 0px; position: absolute; top: 144px; width: 100%;"
+        >
+          Option 4
+        </li>
+      </div>
+    </ul>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/module/src/components/Virtualized/index.ts
+++ b/packages/module/src/components/Virtualized/index.ts
@@ -1,3 +1,5 @@
 export { AutoSizer, WindowScroller } from 'react-virtualized';
 export { VirtualGrid } from './VirtualGrid';
 export { VirtualTableBody } from './VirtualTableBody';
+export { VirtualSelectList } from './VirtualSelectList';
+export type { VirtualSelectListProps, VirtualSelectListRowRendererParams, VirtualSelectListRef } from './VirtualSelectList';


### PR DESCRIPTION
Issue https://github.com/patternfly/react-virtualized-extension/issues/44

## Summary

- Add `VirtualSelectList`, a virtualized replacement for PatternFly's `SelectList` that renders only visible items in a scrollable dropdown, enabling Select menus with thousands of options without DOM performance degradation
- Add `innerScrollContainerClassName` prop to `VirtualGrid` so non-table consumers can override the hardcoded `pf-v6-c-table__tbody` class
- Add documentation examples (basic, typeahead with filtering, multi-select) and 14 unit tests

## Motivation

In [OpenShift Console PR #16252](https://github.com/openshift/console/pull/16252), the Search page Resources dropdown has 1000+ items. After algorithmic optimizations (O(n²) → O(1) lookups, memoization), the remaining bottleneck is PatternFly's `Select` component measuring DOM geometry (`refCallback` forced reflow) after inserting all items. Even capped at 100 items, INP is 270ms ("needs improvement" on Core Web Vitals).

`VirtualSelectList` reduces INP from **270ms → 107ms** ("good"), a **60% further reduction** by rendering only ~10-20 visible items instead of 100.

| Metric | Before (100-item cap) | After (VirtualSelectList) |
|---|---|---|
| INP | 270ms (needs improvement) | **107ms (good)** |
| Processing duration | ~200ms | 77ms |
| Presentation delay | ~70ms | 22ms |

## Usage

Drop-in replacement for `<SelectList>` inside a composable `<Select>`:

```tsx
import { Select, SelectOption, MenuToggle } from '@patternfly/react-core';
import { VirtualSelectList } from '@patternfly/react-virtualized-extension';

<Select isOpen={isOpen} onSelect={onSelect} toggle={toggle} isScrollable>
  <VirtualSelectList
    rowCount={items.length}
    rowHeight={36}
    maxHeight={300}
    rowRenderer={({ index, style, key }) => (
      <SelectOption key={key} style={style} value={items[index]}>
        {items[index]}
      </SelectOption>
    )}
  />
</Select>
```

## Design decisions

- **Wraps `VirtualGrid`** with 1 column, N rows — mirrors `VirtualTableBody` pattern
- **Renders `<ul role="listbox">`** as outer container via `scrollContainerComponent`
- **`rowRenderer` callback** (not children) — required for lazy virtualized rendering, matches `VirtualTableBody.rowRenderer` naming
- **Internal keyboard navigation** — ArrowUp/Down/Home/End with `scrollToRow`
- **Functional component** — modern React style (vs `VirtualTableBody`'s class component)

## Known limitations

- Browser Ctrl+F won't find off-screen items — typeahead filter covers this use case
- Items are absolutely positioned, so the dropdown menu won't auto-size to content width — consumers should set `popperProps={{ minWidth: '...' }}` on the `<Select>`
- No grouped/categorized support — flat lists only; `<SelectGroup>` support is a follow-up

## Test plan

- [x] `yarn build` passes (ESM + CJS)
- [x] `yarn test` — 26 tests pass (14 new for VirtualSelectList, 12 existing unchanged)
- [x] Tested in OpenShift Console against a live cluster with 1000+ API resources
- [x] INP profiled at 107ms (good) via Chrome DevTools Performance trace